### PR TITLE
Fix vlan handling in ebtables/nftables rules

### DIFF
--- a/src/ebtables.c
+++ b/src/ebtables.c
@@ -98,7 +98,7 @@ static void ebtables_do(const char* ifname, const int vlanid, const uint8_t* mac
 
 	const char* op = start ? "-A" : "-D";
 
-	if (vlanid == 0)
+	if (vlanid <= 0)
 		ebtables_novlan(op, ip, mac, ifname);
 	else
 		ebtables_vlan(op, ip, mac, ifname, vlanid);

--- a/src/nftables.c
+++ b/src/nftables.c
@@ -183,7 +183,7 @@ static void nftables_do(const char* ifname, const int vlanid, const uint8_t* mac
 
 	assert(ip); assert(mac); assert(ifname);
 	eprintf(DEBUG_VERBOSE, "%s nftables rule: MAC: %s IP: %s BRIDGE: %s VLAN: %d", start ? "add" : "delete", ether_ntoa_z((struct ether_addr *)mac), inet_ntoa(*ip), ifname, vlanid);
-	if (vlanid == 0)
+	if (vlanid <= 0)
 		nftables_novlan(start, ip, mac, ifname);
 	else
 		nftables_vlan(start, ip, mac, ifname, vlanid);


### PR DESCRIPTION
When --enable-vlan is not used, the default vlanid is -1 instead of 0 and
it tries to use a vlan whose id is -1, which is not correct and the
rules fail.

This commit checks for this value before creating ebtables/nftables rules.

Compiled and tested.